### PR TITLE
Add shebang to starter.rb

### DIFF
--- a/starter.rb
+++ b/starter.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 class Starter
 
   def initialize


### PR DESCRIPTION
Script is now executable without calling ruby first.
ruby starter.rb -> ./starter.rb
